### PR TITLE
delete item functionality in edit item modal

### DIFF
--- a/src/main/java/com/benchwarmers/grads/grizzlystoreitem/controllers/ItemsController.java
+++ b/src/main/java/com/benchwarmers/grads/grizzlystoreitem/controllers/ItemsController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.support.PagedListHolder;
 import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -274,7 +275,7 @@ public class ItemsController {
         JsonResponse response = new JsonResponse();
         Gson g = new Gson();
         Item item = g.fromJson(itemString, Item.class);
-        item.setCategory(category);
+        //item.setCategory(category);
         if (!file.isEmpty()) {
             try {
                 System.out.println("POST REQUEST ACCEPTED");
@@ -305,6 +306,24 @@ public class ItemsController {
         response.addEntity(item);
         return response.createResponse();
     }
+
+    @RequestMapping(path = "/remove", method = RequestMethod.POST)
+    public ResponseEntity removeItem(@RequestBody Item item) {
+        JsonResponse response = new JsonResponse();
+        if (item != null && itemRepository.findItemByIdItem(item.getIdItem()) != null) {
+            Item removedItem = itemRepository.findItemByIdItem(item.getIdItem());
+            removedItem.getCategory().getItems().remove(removedItem);
+            itemRepository.deleteById(item.getIdItem());
+            System.out.println("DELETED");
+            response.setStatus(HttpStatus.OK);
+        }
+        else {
+            response.addErrorMessage("Invalid item object");
+            response.setStatus(HttpStatus.NOT_ACCEPTABLE);
+        }
+        return response.createResponse();
+    }
+
 
     // Allows edits to be made to existing items
     @RequestMapping(path = "/edit", method = RequestMethod.POST)

--- a/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Category.java
+++ b/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Category.java
@@ -25,7 +25,7 @@ public class Category extends Data {
     @Column(name = "categoryDescription", nullable = false)
     private String categoryDescription;
 
-    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Item> items= new ArrayList<>();
 
     @CreationTimestamp

--- a/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Category.java
+++ b/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Category.java
@@ -25,7 +25,7 @@ public class Category extends Data {
     @Column(name = "categoryDescription", nullable = false)
     private String categoryDescription;
 
-    @OneToMany(mappedBy = "category", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Item> items= new ArrayList<>();
 
     @CreationTimestamp
@@ -34,6 +34,7 @@ public class Category extends Data {
     private Date last_modified;
 
     public Category() {
+
     }
 
     public Category(int idCategory, String categoryName, String categoryDescription) {

--- a/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Item.java
+++ b/src/main/java/com/benchwarmers/grads/grizzlystoreitem/entities/Item.java
@@ -61,6 +61,7 @@ public class Item extends Data {
 
     public void setCategory(Category category) {
         this.category = category;
+        category.addItemToList(this);
     }
 
     public Integer getIdItem() {


### PR DESCRIPTION
Delete item functionality within ItemController.java

Altered Category class bidirectional dependency on items, to have FetchType.LAZY for performance issues. Also, when deleting an item from itemRepo, the item is also deleted from the related category. Keeps both entities in sync.

If we delete from item repo and FetchType.EAGER is selected in Category side, no delete happens because CascadeType.ALL on Category means, it even has CascadeType.PERSIST, which means any deleting on Item doesn't work directly.